### PR TITLE
Update ordering of history entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ These commands are for specific chats, either new or existing.
 | --exec        | -x         | Run the output as a shell command                    |
 | --code        |            | Returns code as the response                         |
 | --name        | -n         | Name of chat from history to operate the command on  |
+| --desc        |            | Sort the history entries in descending order         |
 | --repl        |            | Enters a REPL mode with continuous chat              |
 | --retry       | -r         | Regenerate the last assistant message                |
 | --rewrite     | --rw, -w   | Rewrite the last user message & regenerate response  |
@@ -178,6 +179,12 @@ Viewing and resuming past conversation history:
 gpt --history
 # shellgpt-demo-chat
 # cat-tweets
+# ...
+
+gpt --history --desc
+# ...
+# cat-tweets
+# shellgpt-demo-chat
 # ...
 
 gpt --name "cat-tweets" "Generate more, please"

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -214,7 +214,7 @@ export const getChat = async (
  * Get the history of chats
  * @example [{ name: '2021-01-01_12-00-00', time: Date }, { name: '2021-01-01_12-00-00', time: Date }]
  */
-export const getHistory = async (): Promise<{
+export const getHistory = async (descending: boolean = true): Promise<{
   name: string;
   snippet?: string;
   time: Date;
@@ -248,7 +248,8 @@ export const getHistory = async (): Promise<{
     });
   }
 
-  fileInfos.sort((a, b) => b.time.getTime() - a.time.getTime());
+  const sortOrder = descending ? -1 : 1;
+  fileInfos.sort((a, b) => sortOrder * (a.time.getTime() - b.time.getTime()));
 
   // add historySnippets
   let generatedSnippets = false;

--- a/mod.ts
+++ b/mod.ts
@@ -60,6 +60,7 @@ const args = parse(Deno.args, {
     // History (list chat history)
     "history",
     "h",
+    "desc",
 
     // Dump (dump the entire chat history)
     "dump",
@@ -149,6 +150,7 @@ const dump = args.dump || args.d;
 const cont = slice || pop || retry || rewrite || print || dump ||
   (Boolean(args.c || args.cont || args.continue));
 const history = args.h || args.history;
+const descending = args.desc
 const system = args.sys || args.system;
 const maxTokens = args.max || args.max_tokens;
 const readStdin = args._.at(0) === "-" || args._.at(-1) === "-";
@@ -205,6 +207,7 @@ Options:
   --pop               Remove the last message in the conversation
   -p, --print         Print the last message in the conversation
   -h, --history       List chat history
+  --desc              List chat history in descending order. Defaults to ascending order.
   -d, --dump          Dump the entire chat history
   -f, --fast          Use GPT-3.5-turbo model (faster)
   --repl              Start a continuous conversation
@@ -515,7 +518,7 @@ if (exec) {
 }
 
 if (history) {
-  const files = await getHistory();
+  const files = await getHistory(descending);
   for (const file of files) {
     const hasSnippet = file.snippet && file.snippet.length > 0;
     if (hasSnippet) {


### PR DESCRIPTION
Change the default order of history entries to ascending, so we get the oldest entries at the top, and newest entries at the bottom. 
Add new flag to support descending ordering of history entries. 
Update README with the new flag.